### PR TITLE
Add lazy initialization to AdcController

### DIFF
--- a/source/Windows.Devices.Adc/AdcChannel.cs
+++ b/source/Windows.Devices.Adc/AdcChannel.cs
@@ -13,12 +13,19 @@ namespace Windows.Devices.Adc
     /// </summary>
     public sealed class AdcChannel : IAdcChannel, IDisposable
     {
+        // this is used as the lock object 
+        // a lock is required because multiple threads can access the channel
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private readonly object _syncLock = new object();
+
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly int  _channelNumber;
+
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private AdcController _adcController;
 
-        // this is used as the lock object 
-        // a lock is required because multiple threads can access the AdcChannel
-        private object _syncLock = new object();
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        private bool _disposed;
 
         internal AdcChannel(AdcController controller, int channelNumber)
         {
@@ -63,7 +70,7 @@ namespace Windows.Devices.Adc
             lock (_syncLock)
             {
                 // check if pin has been disposed
-                if (_disposedValue) { throw new ObjectDisposedException(); }
+                if (_disposed) { throw new ObjectDisposedException(); }
 
                 return NativeReadValue();
             }
@@ -72,15 +79,13 @@ namespace Windows.Devices.Adc
         private void ThowIfDisposed()
         {
             // check if pin has been disposed
-            if (_disposedValue)
+            if (_disposed)
             {
                 throw new ObjectDisposedException();
             }
         }
 
         #region IDisposable Support
-
-        private bool _disposedValue;
 
         private void Dispose(bool disposing)
         {
@@ -93,7 +98,7 @@ namespace Windows.Devices.Adc
 
                 }
 
-                _disposedValue = true;
+                _disposed = true;
             }
         }
 
@@ -104,7 +109,7 @@ namespace Windows.Devices.Adc
         {
             lock (_syncLock)
             {
-                if (!_disposedValue)
+                if (!_disposed)
                 {
                     Dispose(true);
                     GC.SuppressFinalize(this);

--- a/source/Windows.Devices.Adc/AdcControllerManager.cs
+++ b/source/Windows.Devices.Adc/AdcControllerManager.cs
@@ -1,0 +1,48 @@
+﻿//
+// Copyright (c) 2018 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Collections;
+
+namespace Windows.Devices.Adc
+{
+    internal sealed class AdcControllerManager
+    {
+        private static readonly object _syncLock = new object();
+
+        // backing field for ControllersCollection
+        // to store the controllers that are open
+        private static Hashtable s_controllersCollection;
+
+        /// <summary>
+        /// <see cref="AdcController"/> collection.
+        /// </summary>
+        /// <remarks>
+        /// This collection is for internal use only.
+        /// </remarks>
+        internal static Hashtable ControllersCollection
+        {
+            get
+            {
+                if (s_controllersCollection == null)
+                {
+                    lock (_syncLock)
+                    {
+                        if (s_controllersCollection == null)
+                        {
+                            s_controllersCollection = new Hashtable();
+                        }
+                    }
+                }
+
+                return s_controllersCollection;
+            }
+
+            set
+            {
+                s_controllersCollection = value;
+            }
+        }
+    }
+}

--- a/source/Windows.Devices.Adc/Windows.Devices.Adc.nfproj
+++ b/source/Windows.Devices.Adc/Windows.Devices.Adc.nfproj
@@ -54,6 +54,7 @@
     <Compile Include="AdcChannel.cs" />
     <Compile Include="AdcChannelMode.cs" />
     <Compile Include="AdcController.cs" />
+    <Compile Include="AdcControllerManager.cs" />
     <Compile Include="IAdcChannel.cs" />
     <Compile Include="IAdcController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
## Description
- Add lazy initialization to I2cController.
- Also changed controllersCollection making it accessible as property.
- Add AdcControllerManager allowing multiple ADC controllers.

## Motivation and Context
- Make sure that the variables do exist when being used. Using the previous code was causing issues because, on occasions, the related types could still be unresolved.
- Decorate fields with DebuggerBrowsableState to hide them on debug session.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
