### PR TITLE
Fix bug with controller search and indexing

### DIFF
--- a/source/Windows.Devices.Adc/AdcController.cs
+++ b/source/Windows.Devices.Adc/AdcController.cs
@@ -61,19 +61,20 @@ namespace Windows.Devices.Adc
 
         internal AdcController(string adcController)
         {
-            // check if this device is already opened
-            if (!AdcControllerManager.ControllersCollection.Contains(adcController))
-            {
-                // the ADC id is an ASCII string with the format 'ADCn'
-                // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
-                _controllerId = adcController[3] - '0';
+            // the ADC id is an ASCII string with the format 'ADCn'
+            // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+            _controllerId = adcController[3] - '0';
 
+            // check if this device is already opened
+            if (!AdcControllerManager.ControllersCollection.Contains(_controllerId))
+            {
                 // call native init to allow HAL/PAL inits related with ADC hardware
                 // this is also used to check if the requested ADC actually exists
                 NativeInit();
 
-                // add ADC controller to collection
-                AdcControllerManager.ControllersCollection.Add(adcController, this);
+                // add controller to collection, with the ID as key 
+                // *** just the index number ***
+                AdcControllerManager.ControllersCollection.Add(_controllerId, this);
             }
             else
             {
@@ -165,15 +166,19 @@ namespace Windows.Devices.Adc
 
             if(controllers.Length > 0)
             {
+                // the ADC id is an ASCII string with the format 'ADCn'
+                // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+                var controllerId = controllers[0][3] - '0';
+
                 //////////////////////////////////////////////////////////////////
                 // note that, by design, the default controller is              //
                 // the first one in the collection returned from the native end //
                 //////////////////////////////////////////////////////////////////
 
-                if (AdcControllerManager.ControllersCollection.Contains(controllers[0]))
+                if (AdcControllerManager.ControllersCollection.Contains(controllerId))
                 {
                     // controller is already open
-                    return (AdcController)AdcControllerManager.ControllersCollection[controllers[0]];
+                    return (AdcController)AdcControllerManager.ControllersCollection[controllerId];
                 }
                 else
                 {


### PR DESCRIPTION
## Description
- Controller collection is now searched with the correct index.

## Motivation and Context
- Collection was being searched sometimes with the full AQS and other with the index. Now it's consistently stored and searched with index only.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
