### PR TITLE
Static field objects are now created on constructors.

### DIFF
--- a/source/Windows.Devices.Adc/AdcChannel.cs
+++ b/source/Windows.Devices.Adc/AdcChannel.cs
@@ -16,7 +16,7 @@ namespace Windows.Devices.Adc
         // this is used as the lock object 
         // a lock is required because multiple threads can access the channel
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly object _syncLock = new object();
+        private readonly object _syncLock;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly int  _channelNumber;
@@ -31,6 +31,8 @@ namespace Windows.Devices.Adc
         {
             _adcController = controller;
             _channelNumber = channelNumber;
+
+            _syncLock = new object();
         }
 
         /// <summary>

--- a/source/Windows.Devices.Adc/AdcController.cs
+++ b/source/Windows.Devices.Adc/AdcController.cs
@@ -17,7 +17,7 @@ namespace Windows.Devices.Adc
         // this is used as the lock object 
         // a lock is required because multiple threads can access the AdcController
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly object _syncLock = new object();
+        private object _syncLock;
 
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly int _controllerId;
@@ -75,6 +75,8 @@ namespace Windows.Devices.Adc
                 // add controller to collection, with the ID as key 
                 // *** just the index number ***
                 AdcControllerManager.ControllersCollection.Add(_controllerId, this);
+
+                _syncLock = new object();
             }
             else
             {

--- a/source/Windows.Devices.Adc/AdcControllerManager.cs
+++ b/source/Windows.Devices.Adc/AdcControllerManager.cs
@@ -9,7 +9,7 @@ namespace Windows.Devices.Adc
 {
     internal sealed class AdcControllerManager
     {
-        private static readonly object _syncLock = new object();
+        private static object _syncLock;
 
         // backing field for ControllersCollection
         // to store the controllers that are open
@@ -27,6 +27,11 @@ namespace Windows.Devices.Adc
             {
                 if (s_controllersCollection == null)
                 {
+                    if (_syncLock == null)
+                    {
+                        _syncLock = new object();
+                    }
+
                     lock (_syncLock)
                     {
                         if (s_controllersCollection == null)


### PR DESCRIPTION
## Description
- Static field objects are now created on constructor.

## Motivation and Context
- Creating the static fields objects on the class constructor prevents issues related with using the class or their fields on other static constructor or reference because of the dependencies and the order things get initialized in the CLR.


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

